### PR TITLE
'Video Proxy' references disambiguation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -469,7 +469,7 @@ does not seem to make much sense
 ### Ad Completes at Video Completion ### {#api-complete}
 
 When an ad finishes at the same time as its video.
-1. {{Video proxy}} raises the `AdVideoComplete` event upon video completion.
+1. {{VideoProxy}} raises the `AdVideoComplete` event upon video completion.
 2. Player calls {{Ad/stopAd}}
 3. Ad dispatches `AdStopped` event after it cleans up.
 


### PR DESCRIPTION
Within the document there are references to "video proxy", the terms 'object' and 'element' seem to be used interchangeably. It can create confusion as to whether the Video Player is supposed to provide an actual Proxy Video Element for the SIVIC Ad's Video asset (component) to be loaded and rendered into; **_OR_** if the SIVIC spec is declaring that a Proxy Object for the Video Player's own <video> element exists by which the SIVIC Ad's Interactive asset (component) should enter into communication with the Video Player regarding the SIVIC Ad's Video asset status and control – facilitated by the Video Proxy Interface.

Is the following a more accurate interpretation?

Video Proxy **Object** - collection of properties and values
vs. 
Video Proxy **Element** - HTML DOM <video> element
vs. 
Video Proxy **Interface** - api for accessing an object
