### PR TITLE
Remove error code specific to web site

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -627,7 +627,7 @@ This table indicates defined SIVIC error codes the ad may fire:
 : <dfn>1104</dfn>
 :: Wrong handshake version.
 : <dfn>1105</dfn>
-:: Ad not playable in for a technical reason on this site.
+:: Ad not playable for a technical reason on this site.
 : <dfn>1106</dfn>
 :: Request for expand not honored. The ad requested to expand but the
     player did not allow it.


### PR DESCRIPTION
Specifies that site errors must be for technical reasons. This is to discourage ad creators from trying to use this error message for blocking or selection.  Though blocking and selection will still be possible, it is not in the spirit of the spec and we should make no space for it.

See issue:
https://github.com/InteractiveAdvertisingBureau/SIVIC/issues/44