### PR TITLE
Change language for SIVIC:Player:init section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2443,13 +2443,20 @@ not yet visible (like during initialization) these dimensions will be the expect
      <p><code class="idl"><a data-link-type="idl" href="#dom-resizeparameters-fullscreen" id="ref-for-dom-resizeparameters-fullscreen">fullScreen</a></code> True if fullscreen.</p>
    </ul>
    <h4 class="heading settled" data-level="5.4.2" id="sivic-player-init"><span class="secno">5.4.2. </span><span class="content">SIVIC:Player:init</span><a class="self-link" href="#sivic-player-init"></a></h4>
-   <p>To assist in preloading assets the SIVIC:Player:init before SIVIC:Player:startCreative.
-The player should call this function early enough before playback so that assets can be
-displayed as soon as the ad starts.</p>
-   <p>The ad, however, should not assume that it has any amount of time between the
-SIVIC:Player:init call and the SIVIC:Player:startCreative message. For example a preroll might
-call SIVIC:Player:startCreative immediately after SIVIC:Player:init.</p>
-   <p>When calling SIVIC:Player:init, the player shall provide the following parameters:</p>
+<p>Message SIVIC:Player:init is designed to communicate to creative data that is required prior to cohesive user ad experience invocation. This is the first message player sends to creative. Player should dispatch SIVIC:Player:init before video playback starts to allow creative to complete its internal initialization logic, prepare UI, etc.</p>
+		<p>
+			Message SIVIC:Player:init is unique in a sense that it is the first opportunity player has to communicate its capacities, especially its ability to wait for creative to amicably resolve time-sensitive and asynchronous processes.
+		</p>
+		<p>
+			Under normal circumstances player should wait for creative to respond with "resolve" message before proceeding with ad video rendering and subsequent posting of SIVIC:Player:startCreative message. However, creative shouldn’t assume that player is able to allot time between SIVIC:Player:init and SIVIC:Player:startCreative posts. In certain cases player may be forced to send SIVIC:Player: startCreative immediately after SIVIC:Player:init.
+		</p>
+<p>When posting SIVIC:Player:init, the player shall provide the following arguments of message.args object:</p>
+		<p class="issue">
+			From how arguments are presented the knee jerk reaction is that property args will contain properties that are, in turn, other objects with their cascade of proeprties. It should be made clear whether all properties described in this section are immediate parameters of arg object or they are grouped under specialized objects.
+		</p>
+		<p class="issue">
+			It may make sense to add "reject" message that is linked to SIVIC:Player:init as an alternative to "fatalError" for the consistency sake. 
+		</p>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-initparameters"><code><c- g>initParameters</c-></code><a class="self-link" href="#dictdef-initparameters"></a></dfn> {
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#dictdef-environmentdata" id="ref-for-dictdef-environmentdata"><c- n>EnvironmentData</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="initParameters" data-dfn-type="dict-member" data-export data-type="EnvironmentData " id="dom-initparameters-environmentdata"><code><c- g>EnvironmentData</c-></code></dfn>;
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#dictdef-creativedata" id="ref-for-dictdef-creativedata"><c- n>CreativeData</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="initParameters" data-dfn-type="dict-member" data-export data-type="CreativeData " id="dom-initparameters-creativedata"><code><c- g>CreativeData</c-></code></dfn>;


### PR DESCRIPTION
Current section does not necessarily reflect creative engagement flow. Also it contradicts the fact that "resolve" is expected (or this is an information only message and "resolve" may be useless).