### PR TITLE
Section 5.1 example changed id to type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -516,7 +516,7 @@ For example:
 
 <xmp>
 {
- id: "SIVIC:Tracking:impression",
+ type: "SIVIC:Tracking:impression",
  args: {}
 }
 </xmp>


### PR DESCRIPTION
Message has `type` - not `id` attribute