### PR TITLE
Fix init paragraph

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -717,7 +717,7 @@ To assist in preloading assets the player must send the SIVIC:Player:init messag
 before SIVIC:Player:startCreative.  The player should send this message early
 enough before playback so that assets can be displayed as soon as the ad starts.
 
-The ad, however, should not assume that it has adequate time between the
+The ad, however, should not assume it is given any amount of time between the
 SIVIC:Player:init message and the SIVIC:Player:startCreative message.
 For example a preroll might send SIVIC:Player:startCreative immediately
 after SIVIC:Player:init.


### PR DESCRIPTION
The SIVIC:Player:init message had some typos.  This is mostly a grammatical fix and introduces no new feature changes.