### PR TITLE
Remove transition animation parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -652,7 +652,6 @@ dictionary videoDimensions {
 	required int y;
 	required int width;
 	required int height;
-	float transitionDuration;
 };
 </xmp>
 <xmp class="idl">
@@ -661,7 +660,6 @@ dictionary creativeDimensions {
 	required int y;
 	required int width;
 	required int height;
-	float transitionDuration;
 };
 </xmp>
 
@@ -674,14 +672,12 @@ not yet visible (like during initialization) these dimensions will be the expect
 		- {{videoDimensions/y}} The y offset of the video. It should initialize at 0.
 		- {{videoDimensions/width}} The width in pixels of the video.
 		- {{videoDimensions/height}} The height in pixels of the video.
-		- {{videoDimensions/transitionDuration}} Number in seconds the transition animation should take, this can be accomplished by transition-property in css
 
 - {{creativeDimensions}}
 		- {{videoDimensions/x}} The x offset of the creative. It should initialize at 0.
 		- {{videoDimensions/y}} The y offset of the creative. It should initialize at 0.
 		- {{videoDimensions/width}} The width in pixels of the creative.
 		- {{videoDimensions/height}} The height in pixels of the creative.
-		- {{videoDimensions/transitionDuration}} Number in seconds the transition animation should take, this can be accomplished by transition-property in css
 - {{resizeParameters/fullScreen}} True if fullscreen.
 
 ### SIVIC:Player:init ### {#sivic-player-init}


### PR DESCRIPTION
The original hope was that by telling the player to animate transitions through an animation number would make the user experience better. In a meeting we agreed that publishers would probably have a hard time integrating this complexity.