### PR TITLE
Adds a table for codes for why an adStopped event happens

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -811,8 +811,8 @@ parameters:
 The player should use the following table to determine which code to send.
  - 0: Unspecified
  - 1: User initiated close
- - 2: Ad video playback complete
- - 3: Player initiated close
+ - 2: Ad media playback complete
+ - 3: Player initiating close before media playback complete
  - 4: Creative initiated close
 
 ### SIVIC:Player:fatalError ### {#sivic-player-fatalError}


### PR DESCRIPTION
This gives publishers a way to communicate to creatives why they were closed.  If a publisher doesn't want to do it, it has the option of using the unspecified value.

There was some fear that all publishers would just default to unspecified, but the alternative is to have no code at all in the spec.