### PR TITLE
Remove tracking API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -572,32 +572,6 @@ parameters:
 	this must be calculated to be the total time the video ad has played. For example: if the video element
 	time is 500 seconds but the ad started playback 10 seconds ago (in DAI), currentTime should be set to 10 seconds.
 
-### SIVIC:Video:trackingEvent ### {#sivic-video-trackingevent}
-<xmp class="idl">
-dictionary TrackingParameters {
-  required DOMString event;
-  required record<DOMString, DOMString> macros;
-};
-</xmp>
-
-Anytime the player would send a tracking pixel the player must send
-the SIVIC:Video:trackingEvent message to the creative. Even if there
-is no tracking pixel associated with the event the player must still send
-this message to the SIVIC creative.
-
-For example, if the first quartile of the video is reached the player must send the message
-SIVIC:Video:trackingEvent with the event parameter being firstQuartile. This message must
-be sent regardless of whether or not the player is sending tracking pixels.
-
-The event parameter must match exactly the tracking event name as defined in VAST.
-
-The macros map must be populated with all the macros the player would use on the
-tracking event.
-
-Notes:
-Errors and impressions are also considered tracking events. The progress tracking
-event can be ignored.
-
 ### SIVIC:Video:volumechange ### {#sivic-video-volumechange}
 Should be called after the volumechange event is triggered on the video element.
 


### PR DESCRIPTION
As discussed last week.  The tracking API:
- creates a lot of trouble for players to implement
- could cause Ad makers to confuse SIVIC with tracking validation (which they shouldn't)
- doesn't have a lot of Ad creators in our group asking for it.

So lets remove it.