### PR TITLE
Clarifies behavior of variableDuraion

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1138,10 +1138,11 @@ When a SIMID creative is referenced from a VAST document, the value for the
 Version negotiation should be handled by the [[#api-ad-loading]] algorithm
 (rather than identified in the VAST file).
 
-Another attribute of the `InteractiveCreativeFile` is `variableDuration` which
-identifies whether the ad always drops when the duration is reached, or if it
-can potentially extend the duration by pausing the underlying video or delaying
-the `adStopped` event after `adVideoComplete`.
+Another attribute of the `InteractiveCreativeFile` is `variableDuration`.
+If `variableDuration` is true this means that the ad is only playable if
+the player allows the ad to pause and extend duration. If the player does
+not support this capability, then it must not render the video or creative.
+The player should error out instead.
 
 # Common Workflows # {#common-workflows}
 


### PR DESCRIPTION
Specifies clearly that a player should error out if the ad requires variable duration but the player does not support it.

This is a redo of pr 87 as creating a new branch was quicker than updating that branch.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/InteractiveAdvertisingBureau/SIMID/pull/248.html" title="Last updated on May 9, 2019, 9:26 PM UTC (cd91b5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/InteractiveAdvertisingBureau/SIMID/248/145fe15...cd91b5a.html" title="Last updated on May 9, 2019, 9:26 PM UTC (cd91b5a)">Diff</a>