### PR TITLE
Edited SIMID:Player:adStopped language

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -762,8 +762,9 @@ The player should wait for a response before unloading the creative iframe.
 After resolve is received, the iframe will be removed.
 
 ### SIMID:Player:adStopped ### {#sivic-player-adStopped}
-This indicates the player will stop the ad. The player should hide the creative and stop video playback in this case.
-The player should wait for a response before unloading the creative iframe.
+This message indicates that the player has stopped the ad. The player hides the creative and stops video playback before posting `Player.adStopped`.
+
+The player should wait for the `resolve` response before unloading the creative iframe. The player should implement a reasonable timeout to allow for creative to conclude ad end logic.
 
 parameters:
 - code(int): reason for ad stopping
@@ -774,9 +775,11 @@ The player should use the following table to determine which code to send.
  - 2: Ad media playback complete
  - 3: Player initiating close before media playback complete
  - 4: Creative initiated close
+ 
+In response to `SIMID:Player:adStopped`, creative finalizes the ad end logic and responds with `resolve` message.
 
 #### resolve #### {#sivic-player-adStopped-resolve}
-After resolve is received, the iframe will be removed.
+After resolve is received, the player removes the creative iframe.
 
 ### SIMID:Player:appBackgrounding ### {#sivic-player-app-backgrounding}
 The ad is in app and the app is going to move to the background.


### PR DESCRIPTION
1. Introduced more timeout details.
1. Stopping video and hiding creative is mandatory.
1. Enforces adStopped message reporting **after** video is stopped and iframe becomes invisible.
1. Reads better.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/InteractiveAdvertisingBureau/SIMID/pull/260.html" title="Last updated on Jun 11, 2019, 3:57 PM UTC (683c6ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/InteractiveAdvertisingBureau/SIMID/260/a18a438...683c6ee.html" title="Last updated on Jun 11, 2019, 3:57 PM UTC (683c6ee)">Diff</a>