### PR TITLE
SIMID:Player:adSkipped enhancements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -755,11 +755,12 @@ For example:
 </xmp>
 
 ### SIMID:Player:adSkipped ### {#sivic-player-adSkipped}
-This indicates the player will skip the ad. The player should hide the creative and stop video playback in this case.
-The player should wait for a response before unloading the creative iframe.
+This message indicates that the player has skipped the ad. The player hides the creative and stops video playback before posting `adSkipped` message.
+
+The player waits for a ‘resolve` response before unloading the creative iframe. The player should establish a reasonable timeout to allow for creative ad end logic completion.
 
 #### resolve #### {#sivic-player-adSkipped-resolve}
-After resolve is received, the iframe will be removed.
+Creative finalizes internal ad end logic and responds with `resolve` message. The player removes the creative iframe upon `resolve` arrival.
 
 ### SIMID:Player:adStopped ### {#sivic-player-adStopped}
 This indicates the player will stop the ad. The player should hide the creative and stop video playback in this case.


### PR DESCRIPTION
1. Details of timeout introduced.
1. Video and creative hiding strictly enforced.
1. Clarified that adSkipped is reported **AFTER** video is stopped and iframe becomes invisible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 11, 2019, 4:12 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2Fca7876539555197c2d4c806366a46faa3f8c253c%2Findex.bs&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23261.)._
</details>
