### PR TITLE
Aronschatz new fixes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -781,7 +781,7 @@ SIMID API is a set of messages and data structures that ad-rendering parties exc
 
 SIMID specifies a group of messages that describe ad media states. The player prepends such messages with the `SIMID:Media namespace`.
 
-SIMID borrows media-related semantics and naming conventions from the standard `HTMLMediaElement` behavior. In player implementations, where an `HTMLMediaElement` is not used, the player must translate events and property values into the associated `SIMID:Media` message.
+SIMID borrows media-related semantics and naming conventions from the standard `HTMLMediaElement` behavior. In player implementations where an `HTMLMediaElement` is not used, the player must translate events and property values into the associated `SIMID:Media` message.
 
 In HTML environments, `SIMID:Media` messages contain the original media event type.
 <div class="example">
@@ -843,10 +843,10 @@ dictionary MessageArgs {
 <li>In SSAI, `HTMLMediaElement.duration` value does not express the actual ad media duration. In such cases, the player must compute the ad’s actual media length.</li>
 </ul>
 ### SIMID:Media:ended ### {#simid-media-ended}
-When the media playback completes (in HTML, `HTMLMediaElement` dispatches `ended` event), the player posts a `SIMID:Media:ended` message. 
+When the media playback completes (in HTML, `HTMLMediaElement` dispatches an `ended` event), the player posts a `SIMID:Media:ended` message. 
 
 ### SIMID:Media:error ### {#simid-media-error}
-When playback throws an exception (in HTML, `HTMLMediaElement` dispatches `error` event), the player posts `SIMID:Media:error` message.
+When playback throws an exception (in HTML, `HTMLMediaElement` dispatches an `error` event), the player posts a `SIMID:Media:error` message.
 
 <xmp class="idl">
 dictionary MessageArgs {
@@ -868,10 +868,10 @@ dictionary MessageArgs {
 </dl>
 
 ### SIMID:Media:pause ### {#simid-media-pause}
-When the media pauses (in HTML, `HTMLMediaElement` dispatches `pause` event), the player posts a `SIMID:Media:pause` message.
+When the media pauses (in HTML, `HTMLMediaElement` dispatches a `pause` event), the player posts a `SIMID:Media:pause` message.
 
 ### SIMID:Media:play ### {#simid-media-play}
-When media playback starts as a result of autoplay or its state is no longer paused (in HTML, `HTMLMediaElement` dispatches `play` event),  the player posts a `SIMID:Media:play` message.
+When media playback starts as a result of autoplay or its state is no longer paused (in HTML, `HTMLMediaElement` dispatches a `play` event),  the player posts a `SIMID:Media:play` message.
 
 
 ### SIMID:Media:playing ### {#simid-media-playing}
@@ -881,7 +881,7 @@ The player posts a `SIMID:Media:playing` message in one of the following cases:
 * playback restarts;
 * after seek operation completion. 
 
-In HTML, the player posts `Media:playing` message when `HTMLMediaElement` dispatches `playing` event.
+In HTML, the player posts a `Media:playing` message when `HTMLMediaElement` dispatches a `playing` event.
 
 
 ### SIMID:Media:seeked ### {#simid-media-seeked}

--- a/index.bs
+++ b/index.bs
@@ -928,7 +928,7 @@ dictionary MessageArgs {
   <dd>`true` if audio is muted.*
 </dl>
 <ul class="footnote">
-<li>Properties `volume` and `muted` describe two independent audio states. While media is muted, its `volume` may be greater than zero; while `volume` is zero, media may be unmuted.</li>
+<li>The properties `volume` and `muted` describe two independent audio states. While the media is muted, its `volume` may be greater than zero; while `volume` is zero, the media may be unmuted.</li>
 </ul>
 
 ## Messages from the player ## {#player-messages}
@@ -1056,7 +1056,7 @@ dictionary MessageArgs {
 </dl>
 
 #### resolve #### {#simid-player-fatalError-resolve}
-The creative must respond to `Player:fatalError` with `resolve`. After `resolve arrives`, the player should remove the iframe. 
+The creative must respond to `Player:fatalError` with `resolve`. After `resolve` arrives, the player should remove the iframe. 
 
 ### SIMID:Player:init ### {#simid-player-init}
 The purpose of the `SIMID:player:init` message is to transport data to assist with the interactive component initialization. See [[#workflow-initialization]] and [[#workflow-uninterupted-initialization]].
@@ -1315,7 +1315,7 @@ The creative posts messages to the player to requests the ad’s state changes, 
 
 `SIMID:Creative` messages may require the player to accept and process arguments. With some messages, the creative expects the player to respond with resolutions.
 
-Note: in SIMID, the interactive component initializes the session and posts the first message `createSession`. See [[#protocol-session-layer]].
+Note: In SIMID, the interactive component initializes the session and posts the first message, `createSession`. See [[#protocol-session-layer]].
 
 <p table-header id="table-creative-messages">`SIMID:Creative` messages summary.</p>
 
@@ -1404,7 +1404,7 @@ Note: in SIMID, the interactive component initializes the session and posts the 
 
 The purpose of a `SIMID:Creative:clickThru` message is to assist the player with `clickthrough` tracking. SIMID delegates clickthrough execution to the creative, including redirecting the user to the landing page. The interactive component posts `clickThru` only when the creative classifies a user interaction as a clickthrough.
 
-The message `clickThru` is not an explicit media-pausing directive to the player. If the environment permits, the player should pause ad media in all cases when the user navigates away from the player hosting page or app, including clickthrough. See [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API).
+The message, `clickThru`, is not an explicit media-pausing directive to the player. If the environment permits, the player must pause ad media in all cases when the user navigates away from the player hosting page or app, including clickthrough. See [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API).
 
 <xmp class="idl">
 dictionary MessageArgs {
@@ -1422,7 +1422,7 @@ dictionary MessageArgs {
 
 
 ### SIMID:Creative:fatalError ### {#simid-creative-fatalError}
-The creative posts `SIMID:Creative:fatalError` in cases when its internal exceptions prevent the interactive component from further execution. In response to the `Creative:fatalError` message, the player unloads the SIMID iframe and reports VAST error tracker with the `errorCode` specified by the creative. The ad media playback stops if possible.
+The creative posts `SIMID:Creative:fatalError` in cases when its internal exceptions prevent the interactive component from further execution. In response to the `Creative:fatalError` message, the player unloads the SIMID iframe and reports VAST error tracker with the `errorCode` specified by the creative. The ad media playback must stop, if possible.
 
 <xmp class="idl">
 dictionary MessageArgs {
@@ -1482,7 +1482,7 @@ dictionary MessageArgs {
 The message `SIMID:Creative:log` enables the creative to communicate arbitrary information to the player.
 
 
-Note: If the `log` message purpose is to notify the player about the player’s non-standard behavior, the creative prepends `Message.args.message` value with “WARNING:” `string`. Warning messages are used to inform interested parties about occuraeces of non-fatal issues. 
+Note: If the `log` message purpose is to notify the player about the player’s non-standard behavior, the creative prepends `Message.args.message` value with “WARNING:” `string`. Warning messages are used to inform interested parties about occurances of non-fatal issues. 
 
 <xmp class="idl">
 dictionary MessageArgs {

--- a/index.bs
+++ b/index.bs
@@ -885,20 +885,20 @@ In HTML, the player posts a `Media:playing` message when `HTMLMediaElement` disp
 
 
 ### SIMID:Media:seeked ### {#simid-media-seeked}
-When user finished moving playhead into a new position (in HTML, `HTMLMediaElement` dispatches `seeked` event), the player posts a `SIMID:Media:seeked` message.
+When the user finished moving playhead into a new position (in HTML, `HTMLMediaElement` dispatches a `seeked` event), the player posts a `SIMID:Media:seeked` message.
 
 
 ### SIMID:Media:seeking ### {#simid-media-seeking}
-When user initiates seek operation (in HTML, `HTMLMediaElement` dispatches `seeking` event), the player posts a `SIMID:Media:seeking` message.
+When the user initiates seek operation (in HTML, `HTMLMediaElement` dispatches a `seeking` event), the player posts a `SIMID:Media:seeking` message.
 
 
 ### SIMID:Media:stalled ### {#simid-media-stalled}
-When media data is not available for rendering (in HTML, `HTMLMediaElement` dispatches `stalled` event), the player posts a `SIMID:Media:stalled` message.
+When media data is not available for rendering (in HTML, `HTMLMediaElement` dispatches a `stalled` event), the player posts a `SIMID:Media:stalled` message.
 
 ### SIMID:Media:timeupdate ### {#simid-media-timeupdate}
 The player communicates media playhead position by posting a `SIMID:Media:timeupdate` message. The message `Media:timeupdate` frequency should be not less than every 250ms.
 
-In HTML, the player sends `Media:timeupdate` message when` HTMLMediaElement` dispatches `timeupdate` event.
+In HTML, the player sends a `Media:timeupdate` message when` HTMLMediaElement` dispatches a `timeupdate` event.
 <xmp class="idl">
 dictionary MessageArgs {
 	required float currentTime;
@@ -909,11 +909,11 @@ dictionary MessageArgs {
   <dt><dfn>currentTime</dfn>
   <dd>The value in seconds. In HTML, `HTMLMediaElement.currentTime` property value.
 </dl>
-<p class="note">In Server-Side Ad Insertion, the client-side media playback is a continuous stream, which requires additional `currentTime` calculations. For the current ad, the player must compute `currentTime` value as a delta between the actual playhead position and the time the ad started.</p>
+<p class="note">In Server-Side Ad Insertion, the client-side media playback is a continuous stream which requires additional `currentTime` calculations. For the current ad, the player must compute the `currentTime` value as a delta between the actual playhead position and the time the ad started.</p>
 
 
 ### SIMID:Media:volumechange ### {#simid-media-volumechange}
-When the media audio state changes (in HTML, `HTMLMediaElement` dispatches `volumechange` event), the player posts a `SIMID:Media:volumechange` message.
+When the media audio state changes (in HTML, `HTMLMediaElement` dispatches a `volumechange` event), the player posts a `SIMID:Media:volumechange` message.
 <xmp class="idl">
 dictionary MessageArgs {
 	required float volume;


### PR DESCRIPTION
Grammar and such.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 2, 2020, 2:15 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2Fb61c0268194f3f544f3c75e7311266e50b25ecec%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Line 790 isn't indented enough (needs 1 indent) to be valid Markdown:
"&lt;/div>"
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23328.)._
</details>
