### PR TITLE
Remove notes section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2085,21 +2085,6 @@ This specification does not define the user experience for a close control (clos
 
 The ad creative can also request to be dismissed at any point in time.  An ad creative may opt to show its own controls, including a close control.
 
-## Additional Notes ## {#workflow-notes}
-
-The player may send a [[#simid-player-adStopped]] message at any time. The creative should respond with
-`resolved` after finishing its ad end logic. The player should allow 1 second
-between sending the [[#simid-player-adStopped]] message and receiving `resolved`. The implementer of the
-player should take into consideration that dropping a SIMID ad unit before it has
-dispatched `resolved` may result in tracking discrepancies, and that sending the
-[[#simid-player-adStopped]] message before the ad experience has ended (which is AFTER the optional
-lean-in phase) could harm the overall ad experience.
-
-The SIMID creative may also dispatch [[#simid-creative-requestStop]] at any time, signaling to the
-player that the ad has finished and unloaded. Any further interaction with the
-SIMID creative after `requestStop` may not result in the desired outcome. The same
-is true for `fatalError`.
-
 # Error Handling and Timeouts # {#errors}
 
 If the media cannot be played the player should terminate the ad and fire an error using the standard VAST errors.


### PR DESCRIPTION
The notes section is restating things that are already stated in another section of the code.  So we've decided to remove it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 24, 2020, 2:53 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2F2497ed101a8e65791bd013dd4ed282b8797df51b%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Line 790 isn't indented enough (needs 1 indent) to be valid Markdown:
"&lt;/div>"
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23340.)._
</details>
