### PR TITLE
Fixed typo in ad completion cases

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1994,7 +1994,7 @@ When an ad finishes at the same time as its media.
 2. The player hides the creative.
 3. The creative may dispatch any tracking pixels via [[#simid-creative-reportTracking]]
 4. The creative may wait for a [[#simid-creative-reportTracking-resolve]] response message from the reportTracking message.
-5. The creative dispatches `resolve` on the `adSkipped` message [[#simid-player-adStopped-resolve]].
+5. The creative dispatches `resolve` on the `adStopped` message [[#simid-player-adStopped-resolve]].
 6. The player unloads the ad.
 
 ### Ad Errors Out ### {#workflow-error}
@@ -2011,7 +2011,7 @@ When an player errors out it must follow these steps.
 2. The player hides the creative.
 3. The creative may dispatch any tracking pixels via [[#simid-creative-reportTracking]]
 4. The creative may wait for a [[#simid-creative-reportTracking-resolve]] response from the reportTracking message.
-5. The creative dispatches `resolve` on the `adSkipped` message [[#simid-player-fatalError-resolve]].
+5. The creative dispatches `resolve` on the `fatalError` message [[#simid-player-fatalError-resolve]].
 6. The player unloads the ad.
 
 ### Ad Requests Stop ### {#workflow-request-stop}


### PR DESCRIPTION
This is a simple typo fix.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 27, 2020, 8:56 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2Fa50d86999d6b6c12db12f16e79b1c2c9d45b0dee%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Line 790 isn't indented enough (needs 1 indent) to be valid Markdown:
"&lt;/div>"
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23341.)._
</details>
