### PR TITLE
Removed appBackgournded resolve response deprecation note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1032,9 +1032,7 @@ The creative must respond to `Player:adStopped` with `resolve` once its internal
 Within mobile in-app ads, when the app moves to the background, the player posts a `SIMID:Player:appBackgrounded` message.
 
 #### resolve #### {#simid-player-app-backgrounded-resolve}
-
-
-<p class="note" warning>Response to `appBackgrounded` with `resolve` has been deprecated.</p>
+The creative resonds to `appBackgrounded` with `resolve` message.
 
 ### SIMID:Player:appForegrounded ### {#simid-player-app-foregrounded}
 Within mobile in-app ad executions, when the app moves from the background to the foreground, the player posts a `SIMID:Player:appForegrounded` message.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 28, 2020, 3:04 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2F00f317f69b244e721544d61a99e363f4dd61670a%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Line 790 isn't indented enough (needs 1 indent) to be valid Markdown:
"&lt;/div>"
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23346.)._
</details>
