### PR TITLE
Refactors promises to be more simple to read

### DIFF
--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -65,15 +65,35 @@ class SimidPlayer {
     /**
      * Resolution function for the session created message
      */
-    this.sessionCreatedResolve_ = null;
+    this.resolveSessionCreatedPromise_ = null;
 
     /**
      * A promise that resolves once the creative creates a session.
      * @private {?Promise}
      */
-    this.sessionCreated_ = new Promise((resolve, reject) => {
-      this.sessionCreatedResolve_ = resolve;
+    this.sessionCreatedPromise_ = new Promise((resolve, reject) => {
+      this.resolveSessionCreatedPromise_ = resolve;
     });
+
+    /**
+     * Resolution function for the ad being initialized.
+     */
+    this.resolveInitializationPromise_ = null;
+
+    /**
+     * Reject function for the ad being initialized.
+     */
+    this.rejectInitializationPromise_ = null;
+
+    /**
+     * A promise that resolves once the creative responds to initialization with resolve.
+     * @private {?Promise}
+     */
+    this.initializationPromise_ = new Promise((resolve, reject) => {
+      this.resolveInitializationPromise_ = resolve;
+      this.rejectInitializationPromise_ = reject;
+    });
+
 
     this.trackEventsOnVideoElement_();
     this.hideAdPlayer_();
@@ -88,6 +108,10 @@ class SimidPlayer {
     // sendInitMessage.
     this.simidIframe_ = this.createSimidIframe_();
     this.requestDuration_ = NO_REQUESTED_DURATION;
+    this.sessionCreatedPromise_.then(() => {
+      this.sendInitMessage_()
+    });
+
   }
 
   /**
@@ -95,11 +119,13 @@ class SimidPlayer {
    */
   playAd() {
     this.contentVideoElement_.pause();
-    // First make sure that a session is created.
-    this.sessionCreated_.then(() => {
-      // Once the creative responds to the initialize message, start playback.
-      this.initializationPromise_.then(this.startCreativePlayback_.bind(this))
-          .catch(this.onAdInitializedFailed_.bind(this));
+    // This example waits for the ad to be initialized, before playing video.
+    // NOTE: Not all players will wait for session creation and initialization
+    // before they start playback.
+    this.initializationPromise_.then(() =>  {
+      this.startCreativePlayback_()
+    }).catch(() => {
+      this.onAdInitializedFailed_()
     });
   }
 
@@ -132,7 +158,7 @@ class SimidPlayer {
    * @private
    */
   addListeners_() {
-    this.simidProtocol.addListener(ProtocolMessage.CREATE_SESSION, this.sendInitMessage.bind(this));
+    this.simidProtocol.addListener(ProtocolMessage.CREATE_SESSION, this.onSessionCreated_.bind(this));
     this.simidProtocol.addListener(CreativeMessage.REQUEST_FULL_SCREEN, this.onRequestFullScreen.bind(this));
     this.simidProtocol.addListener(CreativeMessage.REQUEST_PLAY, this.onRequestPlay.bind(this));
     this.simidProtocol.addListener(CreativeMessage.REQUEST_PAUSE, this.onRequestPause.bind(this));
@@ -142,6 +168,15 @@ class SimidPlayer {
     this.simidProtocol.addListener(CreativeMessage.REQUEST_CHANGE_AD_DURATION,
         this.onRequestChangeAdDuration.bind(this));
     this.simidProtocol.addListener(CreativeMessage.GET_MEDIA_STATE, this.onGetMediaState.bind(this));
+  }
+
+  /**
+   * Resolves the session created promise.
+   */
+  onSessionCreated_() {
+    // Anything that must happen after the session is created can now happen
+    // since this promise is resolved.
+    this.resolveSessionCreatedPromise_();
   }
 
   destroySimidIframe() {
@@ -178,8 +213,9 @@ class SimidPlayer {
 
   /**
    * Initializes the SIMID creative with all data it needs.
+   * @private
    */
-  sendInitMessage() {
+  sendInitMessage_() {
     const videoDimensions = this.getDimensions(this.contentVideoElement_);
     // Since the creative starts as hidden it will take on the
     // video element dimensions, so tell the ad about those dimensions.
@@ -213,10 +249,13 @@ class SimidPlayer {
       'environmentData' : environmentData,
       'creativeData': creativeData
     }
-    this.initializationPromise_ = this.simidProtocol.sendMessage(
+    const initPromise = this.simidProtocol.sendMessage(
         PlayerMessage.INIT, initMessage);
-    // It is possible that start is called before this initializationm message is sent.
-    this.sessionCreatedResolve_();
+    initPromise.then(()=> {
+      this.resolveInitializationPromise_();
+    }).catch(() => {
+      this.rejectInitializationPromise_();
+    })
   }
 
   /**

--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -64,12 +64,13 @@ class SimidPlayer {
 
     /**
      * Resolution function for the session created message
+     * @private {?Function}
      */
     this.resolveSessionCreatedPromise_ = null;
 
     /**
      * A promise that resolves once the creative creates a session.
-     * @private {?Promise}
+     * @private {!Promise}
      */
     this.sessionCreatedPromise_ = new Promise((resolve, reject) => {
       this.resolveSessionCreatedPromise_ = resolve;
@@ -77,17 +78,19 @@ class SimidPlayer {
 
     /**
      * Resolution function for the ad being initialized.
+     * @private {?Function}
      */
     this.resolveInitializationPromise_ = null;
 
     /**
      * Reject function for the ad being initialized.
+     * @private {?Function}
      */
     this.rejectInitializationPromise_ = null;
 
     /**
      * A promise that resolves once the creative responds to initialization with resolve.
-     * @private {?Promise}
+     * @private {!Promise}
      */
     this.initializationPromise_ = new Promise((resolve, reject) => {
       this.resolveInitializationPromise_ = resolve;

--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -175,6 +175,7 @@ class SimidPlayer {
 
   /**
    * Resolves the session created promise.
+   * @private
    */
   onSessionCreated_() {
     // Anything that must happen after the session is created can now happen


### PR DESCRIPTION
The new workflow introduces 2 promises:
1. sessionCreatedPromise_ that resolves when the simid creative initializes a session.
2. resolveInitializationPromise_ that resolves when initialization is resolved.

The workflow should be:
1. Creative creates  a session.
2. Player calls SIMID:player:Init
3. Creative calls SIMID:Player:startCreative

However, these are all asynchronous so they may be called out of order. In order to keep these in order, this sample code uses promises.

Calling Init will 
1. wait for the session to be created (via sessionCreatedPromise_) 
2. then call SIMID:player:init


Calling playAd will:
1. Wait for the creative to respond to the initialization message (via resolveInitializationPromise_)
2. then call SIMID:player:startCreative