### PR TITLE
Fix init reject bug

### DIFF
--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -410,8 +410,7 @@ class SimidPlayer {
     this.hideAdPlayer_();
     this.adVideoElement_.src = '';
     this.destroySimidIframe();
-    // TODO don't comment next line
-    //this.contentVideoElement_.play();
+    this.contentVideoElement_.play();
   }
 
   /** The creative wants to go full screen. */


### PR DESCRIPTION
Previously when a creative responded with reject to an init message this would cause an error because we were not listening for a reject message immediately.

Also:
- Fixes a bug where the parameters of the reject message were not being passed through.
- Logs the parameters from the reject message.
