### PR TITLE
X button bug

### DIFF
--- a/examples/player/simid_player.html
+++ b/examples/player/simid_player.html
@@ -23,9 +23,9 @@
     }
   </style>
   <script>
-    /** DISABLED and ENABLED constants are used to control the state of buttons. */
-    const DISABLED = true;
-    const ENABLED = false;
+    // /** DISABLED and ENABLED constants are used to control the state of buttons. */
+    // const DISABLED = true;
+    // const ENABLED = false;
 
     //if ad is non-linear allow user to insert specific dimensions
     function enableDisable() {
@@ -54,23 +54,12 @@
       simidPlayer.initializeAd();
     }
 
-    /**Disables or enables stop, skip, and fatal error buttons
-     *  depending on if the ad is showing.
-     * @param {boolean} disable If buttons should be disabled or enabled
-     */
-    function setCreativeControlsState(controlState) {
-      let adRequests = document.querySelectorAll(".ad_request");
-      adRequests.forEach((request) => {
-        request.disabled = controlState;
-      });
-    }
-
     function playAd() {
       if (!simidPlayer) {
         initAd();
       }
       simidPlayer.playAd();
-      setCreativeControlsState(/* controlState= */ ENABLED);
+      simidPlayer.setCreativeControlsState_(/* controlState= */ ENABLED);
     }
 
     function closeAd() {
@@ -79,7 +68,7 @@
       }
       simidPlayer.stopAd();
       simidPlayer.sendLog("User clicked close ad button on player");
-      setCreativeControlsState(/* controlState= */ DISABLED);
+      simidPlayer.setCreativeControlsState_(/* controlState= */ DISABLED);
     }
 
     function skipAd() {
@@ -88,7 +77,7 @@
       }
       simidPlayer.skipAd();
       simidPlayer.sendLog("User clicked skip ad button on player");
-      setCreativeControlsState(/* controlState= */ DISABLED);
+      simidPlayer.setCreativeControlsState_(/* controlState= */ DISABLED);
     }
 
     function fatalError() {
@@ -97,7 +86,7 @@
       }
       simidPlayer.stopAd();
       simidPlayer.sendLog("User clicked fatal error button on player");
-      setCreativeControlsState(/* controlState= */ DISABLED);
+      simidPlayer.setCreativeControlsState_(/* controlState= */ DISABLED);
     }
 
     function switchCreative(value) {

--- a/examples/player/simid_player.html
+++ b/examples/player/simid_player.html
@@ -23,10 +23,6 @@
     }
   </style>
   <script>
-    // /** DISABLED and ENABLED constants are used to control the state of buttons. */
-    // const DISABLED = true;
-    // const ENABLED = false;
-
     //if ad is non-linear allow user to insert specific dimensions
     function enableDisable() {
       let isNonLin = document.getElementById("nonlinear_ad");

--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -495,7 +495,6 @@ class SimidPlayer {
       const closeMessage = {
         'code': reason,
       }
-      this.setCreativeControlsState_(/* controlState= */ DISABLED);
       // Wait for the SIMID creative to acknowledge stop and then clean
       // up the iframe.
       this.simidProtocol.sendMessage(PlayerMessage.AD_STOPPED)
@@ -523,6 +522,7 @@ class SimidPlayer {
     this.hideAdPlayer_();
     this.adVideoElement_.src = '';
     this.destroySimidIframe();
+    this.setCreativeControlsState_(/* controlState= */ DISABLED);
     this.contentVideoElement_.play();
   }
 

--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -1,5 +1,10 @@
 const NO_REQUESTED_DURATION = 0;
 const UNLIMITED_DURATION = -2;
+
+/** DISABLED and ENABLED constants are used to control the state of buttons. */
+const DISABLED = true;
+const ENABLED = false;
+
 /** 
  * All the logic for a simple SIMID player
  */
@@ -403,6 +408,19 @@ class SimidPlayer {
   }
 
   /**
+   * Disables or enables stop, skip, and fatal error buttons
+   *  depending on if the ad is showing.
+   * @private
+   * @param {boolean} controlState If buttons should be disabled or enabled
+   */
+  setCreativeControlsState_(controlState) {
+    let adRequests = document.querySelectorAll(".ad_request");
+    adRequests.forEach((request) => {
+      request.disabled = controlState;
+    });
+  }
+
+  /**
    * Tracks the events on the video element specified by the simid spec
    * @private
    */
@@ -477,6 +495,7 @@ class SimidPlayer {
       const closeMessage = {
         'code': reason,
       }
+      this.setCreativeControlsState_(/* controlState= */ DISABLED);
       // Wait for the SIMID creative to acknowledge stop and then clean
       // up the iframe.
       this.simidProtocol.sendMessage(PlayerMessage.AD_STOPPED)

--- a/examples/simid_protocol.js
+++ b/examples/simid_protocol.js
@@ -10,7 +10,7 @@ class SimidProtocol {
      * A map of messsage type to an array of callbacks.
      * @private {Map<String, Array<Function>>}
      */
-    this.listeners_ = new Map();
+    this.listeners_ = {};
 
     /*
      * The session ID for this protocol.
@@ -38,7 +38,7 @@ class SimidProtocol {
 
   /* Reverts this protocol to its original state */
   reset() {
-    this.listeners_.clear();
+    this.listeners_ = {};
     this.sessionId_ = '';
     this.nextMessageId_ = 1;
     // TODO: Perhaps we should reject all associated promises.


### PR DESCRIPTION
-Fixed bug where iframe listeners weren't being cleared properly so the iframe was considered null when it was actually initialized --> this problem created the error where you were unable to close and iframe, initialize a new one and close the second iframe because the functions would still try to close the first iframe the second time around
-Fixed the bug where the player buttons didn't disable when closing the ad from the creative 