### PR TITLE
Added new non linear error messages.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1907,6 +1907,19 @@ The creative may respond with a `reject` based on its internal logic. In respons
 </div>
 
 
+## Nonlinear Initialization and Start WorkFlow ## {#workflow-initialization-nonlinear}
+
+1. The player creates a hidden iframe and loads the creative.  This can happen before the ad display time to preload the ad.
+1. The creative will initialize a session.
+1. If the creative doesn’t initialize a session within a reasonable timeout the player drops the creative and reports an error.
+1. The player sends a [[#simid-player-init]] message with relevant parameters.
+1. If the player can initialize the creative responds with resolve.
+1. If the creative responds with reject or doesn’t respond in time the player drops the creatives iframe and reports an error.
+1. When the player is ready to show the iframe the player sends a [[#simid-player-startCreative]] message.
+1. If the creative responds with reject or doesn’t respond in time the player drops the creatives iframe and reports an error.
+1. When the creative responds with resolve, the player makes the iframe visible.
+
+
 ## How to Handle Ad Playback ## {#workflow-ad-playback}
 
 The media player is responsible for ad media playback handling as well as tracking media related events. The SIMID creative manages interactive content and internal tracking related to interactivity.
@@ -2484,6 +2497,51 @@ The table below is the list of error codes the player and the creative use with 
       <td>1213</td>
       <td>The SIMID creative did not reply to the start message.</td>
       <td></td>
+    </tr>
+    <tr>
+      <td>1214</td>
+      <td>Environment does not support navigation.</td>
+      <td>The creative asked to open a navigation window, but the environment doesn’t support it. The creative should be opening the navigation window.</td>
+    </tr>
+    <tr>
+      <td>1215</td>
+      <td>Navigation not possible at all on this device.</td>
+      <td>The creative asked for a navigation. However, navigation window opening is not possible at all on this device.</td>
+    </tr>
+    <tr>
+      <td>1216</td>
+      <td>Too many calls to requestNavigation.</td>
+      <td>The creative asked for request navigation too many times and call will be blocked.</td>
+    </tr>
+    <tr>
+      <td>1217</td>
+      <td>Invalid navigation request URL.</td>
+      <td>The creative requested navigation but the url was invalid.</td>
+    </tr>
+    <tr>
+      <td>1218</td>
+      <td>Invalid navigation request app.</td>
+      <td>The creative requested a play store/app store url but that is not valid on this device.</td>
+    </tr>
+    <tr>
+      <td>1219</td>
+      <td>Extra clickthrough blocked.</td>
+      <td>Clickthrough has been reported once, but the creative has requested clickthrough again. No click through will be reported.</td>
+    </tr>
+    <tr>
+      <td>1220</td>
+      <td>Expand not possible due to problem pausing.</td>
+      <td>Player is rejecting expandNonlinear because it cannot pause media. Player should have informed creative it cannot do this on init.</td>
+    </tr>
+    <tr>
+      <td>1221</td>
+      <td>Expand ad rejected by user.</td>
+      <td>User has indicated that the ad should be collapsed so the player will not allow expand.</td>
+    </tr>
+    <tr>
+      <td>1222</td>
+      <td>Too many calls to RequestExpand.</td>
+      <td>Player only allows a number of expands, and that limitation is exceeded.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
1214 | Environment does not support navigation. | The creative asked to open a navigation window, but the environment doesn’t support it. The creative should be opening the navigation window.
-- | -- | --
1215 | Navigation not possible at all on this device. | The creative asked for a navigation. However, navigation window opening is not possible at all on this device.
1216 | Too many calls to requestNavigation. | The creative asked for request navigation too many times and call will be blocked.
1217 | Invalid navigation request URL. | The creative requested navigation but the url was invalid.
1218 | Invalid navigation request app. | The creative requested a play store/app store url but that is not valid on this device.
1219 | Extra clickthrough blocked. | Clickthrough has been reported once, but the creative has requested clickthrough again. No click through will be reported.
1220 | Expand not possible due to problem pausing. | Player is rejecting expandNonlinear because it cannot pause media. Player should have informed creative it cannot do this on init.
1221 | Expand ad rejected by user. | User has indicated that the ad should be collapsed so the player will not allow expand.
1222 | Too many calls to RequestExpand. | Player only allows a number of expands, and that limitation is exceeded.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 27, 2020, 8:39 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2F4a806ccdbe4b5d98cf472615a151c8218aea318c%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Line 790 isn't indented enough (needs 1 indent) to be valid Markdown:
"&lt;/div>"
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23376.)._
</details>
