### PR TITLE
Adds SIMID:Player:collapse API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -688,12 +688,12 @@ SIMID API is a set of messages and data structures that ad-rendering parties exc
       <td>n/a</td>
     </tr>
     <tr>
-      <td>[[#simid-player-collapseNonlinear]]</td>
+      <td>[[#simid-player-app-foregrounded]]</td>
       <td>n/a</td>
       <td>n/a</td>
     </tr>
     <tr>
-      <td>[[#simid-player-app-foregrounded]]</td>
+      <td>[[#simid-player-collapseNonlinear]]</td>
       <td>n/a</td>
       <td>n/a</td>
     </tr>
@@ -1071,7 +1071,7 @@ The player may resize the ad to its default dimensions without the creative requ
 
 The player posts the [[#simid-player-collapseNonlinear]] message before it resizes the creative iframe.
 
-The Player:collapseNonlinear is an information-only message; there are no associated resolution responses.
+The [[#simid-player-collapseNonlinear]] is an information-only message; there are no associated resolution responses.
 
 ### SIMID:Player:fatalError ### {#simid-player-fatalError}
 The player posts a `SIMID:Player:fatalError` message when it encounters exceptions that disqualify the ad from displaying any longer. If feasible, the player stops the ad media. 

--- a/index.bs
+++ b/index.bs
@@ -688,6 +688,11 @@ SIMID API is a set of messages and data structures that ad-rendering parties exc
       <td>n/a</td>
     </tr>
     <tr>
+      <td>[[#simid-player-collapseNonlinear]]</td>
+      <td>n/a</td>
+      <td>n/a</td>
+    </tr>
+    <tr>
       <td>[[#simid-player-app-foregrounded]]</td>
       <td>n/a</td>
       <td>n/a</td>
@@ -1059,6 +1064,14 @@ The creative resonds to `appBackgrounded` with `resolve` message.
 
 ### SIMID:Player:appForegrounded ### {#simid-player-app-foregrounded}
 Within mobile in-app ad executions, when the app moves from the background to the foreground, the player posts a `SIMID:Player:appForegrounded` message.
+
+### SIMID:Player:collapseNonlinear ###  {#simid-player-collapseNonlinear}
+
+The player may resize the ad to its default dimensions without the creative requesting a collapse. The player may collapse the ad based on its internal logic or in response to the user resuming media playback.
+
+The player posts the [[#simid-player-collapseNonlinear]] message before it resizes the creative iframe.
+
+The Player:collapseNonlinear is an information-only message; there are no associated resolution responses.
 
 ### SIMID:Player:fatalError ### {#simid-player-fatalError}
 The player posts a `SIMID:Player:fatalError` message when it encounters exceptions that disqualify the ad from displaying any longer. If feasible, the player stops the ad media. 


### PR DESCRIPTION
This is an information only API. It is exclusively for the player to tell the creative it will collapse it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 4, 2020, 7:15 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2Fb446484bc798d2c8cd904611fa461f776a299340%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Line 813 isn't indented enough (needs 1 indent) to be valid Markdown:
"&lt;/div>"
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23393.)._
</details>
