### PR TITLE
No session created error code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2815,7 +2815,7 @@ The table below is the list of error codes the player and the creative use with 
     <tr>
       <td>1223</td>
       <td>Session not created.</td>
-      <td>Creative did not create session. This error could be triggered after a timeout or upon the end of the media playback.</td>
+      <td>The creative did not create a session. This error could be triggered after a timeout or upon the end of the media playback.</td>
     </tr>
   </tbody>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -2812,6 +2812,11 @@ The table below is the list of error codes the player and the creative use with 
       <td>Player received excessive number of [[#simid-creative-expandNonlinear]] messages.</td>
       <td>Player limits a number of nonlinear ad expands, and that limitation is exceeded.</td>
     </tr>
+    <tr>
+      <td>1223</td>
+      <td>Session not created.</td>
+      <td>Creative did not create session. This error could be triggered after a timeou or upon the end of the media playback.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -2815,7 +2815,7 @@ The table below is the list of error codes the player and the creative use with 
     <tr>
       <td>1223</td>
       <td>Session not created.</td>
-      <td>Creative did not create session. This error could be triggered after a timeou or upon the end of the media playback.</td>
+      <td>Creative did not create session. This error could be triggered after a timeout or upon the end of the media playback.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This is an error code a player can use if the creative doesn't create a session.

Some players might play the entire media before reporting this sort of an error, other players (like non linear players) might time out. 

https://github.com/InteractiveAdvertisingBureau/SIMID/issues/315


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 3, 2020, 6:11 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2F096d73299b629f6f9a87916df32e2f98b5180f22%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Line 513 isn't indented enough (needs 1 indent) to be valid Markdown:
"  * New messages [[#simid-creative-expandNonlinear]], [[#simid-creative-collapseNonlinear]], and [[#simid-player-collapseNonlinear]]."
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23407.)._
</details>
