### PR TITLE
Rename expand and collapse to correct APIs

### DIFF
--- a/examples/creatives/banner_nonlinear.js
+++ b/examples/creatives/banner_nonlinear.js
@@ -88,12 +88,12 @@ class BannerNonLinear extends BaseSimidCreative {
     addButtonClickActions_() {
         this.sendMessageOnButtonClick_('close_ad', CreativeMessage.REQUEST_STOP);
         
-        this.sendMessageOnButtonClick_('ad_text', CreativeMessage.REQUEST_EXPAND, () => {
+        this.sendMessageOnButtonClick_('ad_text', CreativeMessage.EXPAND_NONLINEAR, () => {
             document.getElementById('ad_text').classList.add('hidden');
             document.getElementById('content_box').classList.remove('hidden');
         });
 
-        this.sendMessageOnButtonClick_('minimize_ad', CreativeMessage.REQUEST_COLLAPSE, () => {
+        this.sendMessageOnButtonClick_('minimize_ad', CreativeMessage.COLLAPSE_NONLINEAR, () => {
             document.getElementById('ad_text').classList.remove('hidden');
             document.getElementById('content_box').classList.add('hidden');
         });

--- a/examples/creatives/testers_nonlinear.js
+++ b/examples/creatives/testers_nonlinear.js
@@ -14,8 +14,8 @@ class TestersNonLinear extends BaseSimidCreative {
    */
   addButtonClickActions_() {
     this.sendMessageOnButtonClick_("close_ad", CreativeMessage.REQUEST_STOP);
-    this.sendMessageOnButtonClick_("expand_button", CreativeMessage.REQUEST_EXPAND);
-    this.sendMessageOnButtonClick_("collapse_button", CreativeMessage.REQUEST_COLLAPSE);
+    this.sendMessageOnButtonClick_("expand_button", CreativeMessage.EXPAND_NONLINEAR);
+    this.sendMessageOnButtonClick_("collapse_button", CreativeMessage.COLLAPSE_NONLINEAR);
   }
 
   /**

--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -241,8 +241,8 @@ class SimidPlayer {
         this.onRequestChangeAdDuration.bind(this));
     this.simidProtocol.addListener(CreativeMessage.GET_MEDIA_STATE, this.onGetMediaState.bind(this));
     this.simidProtocol.addListener(CreativeMessage.LOG, this.onReceiveCreativeLog.bind(this));
-    this.simidProtocol.addListener(CreativeMessage.REQUEST_EXPAND, this.onExpandResize.bind(this));
-    this.simidProtocol.addListener(CreativeMessage.REQUEST_COLLAPSE, this.onRequestCollapse.bind(this));
+    this.simidProtocol.addListener(CreativeMessage.EXPAND_NONLINEAR, this.onExpandResize.bind(this));
+    this.simidProtocol.addListener(CreativeMessage.COLLAPSE_NONLINEAR, this.onCollapse.bind(this));
     this.simidProtocol.addListener(CreativeMessage.REQUEST_RESIZE, this.onRequestResize.bind(this));
   }
 
@@ -387,7 +387,7 @@ class SimidPlayer {
    * The creative wants to collapse the ad. 
    * @param {!Object} incomingMessage Message sent from the creative to the player
    */
-  onRequestCollapse(incomingMessage) {
+  onCollapse(incomingMessage) {
     const newDimensions = this.getNonlinearDimensions_();
 
     if (this.isLinearAd_) {

--- a/examples/simid_protocol.js
+++ b/examples/simid_protocol.js
@@ -306,6 +306,8 @@ PlayerMessage = {
 /** Messages from the creative */
 CreativeMessage = {
   CLICK_THRU: 'Creative:clickThru',
+  EXPAND_NONLINEAR: 'Creative:expandNonlinear',
+  COLLAPSE_NONLINEAR: 'Creative:collapseNonlinear',
   FATAL_ERROR: 'Creative:fatalError',
   GET_MEDIA_STATE: 'Creative:getMediaState',
   LOG: 'Creative:log',
@@ -319,8 +321,6 @@ CreativeMessage = {
   REQUEST_TRACKING: 'Creative:reportTracking',
   REQUEST_CHANGE_AD_DURATION: 'Creative:requestChangeAdDuration',
   REQUEST_RESIZE: 'Creative:requestResize',
-  REQUEST_EXPAND: 'Creative:requestExpand',
-  REQUEST_COLLAPSE: 'Creative:requestCollapse',
 };
 
 /**


### PR DESCRIPTION
When we built the sample code we had not chosen the correct expand and collapse API names. This makes the sample consistent with the spec.

Pointed out by streiko
https://github.com/InteractiveAdvertisingBureau/SIMID/issues/406