### PR TITLE
Player:init skipoffset parameter and its description added

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1200,6 +1200,7 @@ dictionary EnvironmentData {
 	required boolean fullscreenAllowed;
 	required boolean variableDurationAllowed;
 	required SkippableState skippableState;
+	DOMString skipoffset;
 	required DOMString version;
 	DOMString siteUrl;
 	DOMString appId;
@@ -1207,9 +1208,9 @@ dictionary EnvironmentData {
 	DOMString deviceId;
 	boolean muted;
 	float volume;
-  NavigationSupport navigationSupport;
-  CloseButtonSupport closeButtonSupport;
-  float nonlinearDuration;
+	NavigationSupport navigationSupport;
+	CloseButtonSupport closeButtonSupport;
+	float nonlinearDuration;
 };
 
 dictionary Dimensions {
@@ -1279,6 +1280,11 @@ enum CloseButtonSupport {"adHandles", "playerHandles"};
 				<li>will disregard skip request from the creative.</li>
 			</ul>
 			With both `playerHandles` and `notSkippable`, the creative avoids the <button skip-ad>Skip Ad</button> button drawing.
+	<dt><dfn>skipoffset</dfn>
+	<dd>Optional parameter that communicates the time the ad becomes skippable for the current session. 
+	<p>The `skipoffset` value format is `"HH:MM:SS"` or `"HH:MM:SS.mmm"`.</p>
+	The value can differ from the `skipoffset` in the VAST response when the player controls skippability. 
+	If the parameter's `skippableState` value is `"adHandles"`, the creative must display the <button skip-ad>Skip Ad</button> button when media playback arrives at the time specified by the `skipoffset` parameter.
 	<dt><dfn>version</dfn>
 	<dd>The SIMID version the player implements.
 	<dt><dfn>muted</dfn>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 3, 2020, 12:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2Fe1fe7c0f54d65278be8ee2859da2fe6a2e2da771%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Line 513 isn't indented enough (needs 1 indent) to be valid Markdown:
"  * New messages [[#simid-creative-expandNonlinear]], [[#simid-creative-collapseNonlinear]], and [[#simid-player-collapseNonlinear]] and related data."
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23409.)._
</details>
