### PR TITLE
Negative 1 indicates unknown size

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1227,9 +1227,9 @@ enum CloseButtonSupport {"adHandles", "playerHandles"};
 
 <dl dfn-type=attribute dfn-for=FooInterface class="idl highlight def">
 	<dt><dfn>videoDimensions</dfn>
-	<dd>Communicates media element coordinates and size.
+	<dd>Communicates media element coordinates and size. -1 indicates an unknown value.
 	<dt><dfn>creativeDimensions</dfn>
-	<dd>Communicates creative iframe coordinates and size the player will set when iframe becomes visible.
+	<dd>Communicates creative iframe coordinates and size the player will set when iframe becomes visible. -1 indicates an unknown value.
 	<dt><dfn>fullscreen</dfn>
 	<dd>The value `true` indicates that the player is currently in fullscreen mode.
 	<dt><dfn>fullscreenAllowed</dfn>


### PR DESCRIPTION
For video dimensions or creative dimensions, it is possible that initialize will be called, but the publisher or sdk that implements SIMID may not yet know the dimensions as it may not itself be fully initialized.

In this situation, it will send the simid creative -1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 28, 2020, 5:11 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FInteractiveAdvertisingBureau%2FSIMID%2Fdb4d14fd85cc55f3b0bda3e30768342593f0ad39%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Line 513 isn't indented enough (needs 1 indent) to be valid Markdown:
"  * New messages [[#simid-creative-expandNonlinear]], [[#simid-creative-collapseNonlinear]], and [[#simid-player-collapseNonlinear]] and related data."
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20InteractiveAdvertisingBureau/SIMID%23415.)._
</details>
