### PR TITLE
changed event name and args in players.js for duration changed

### DIFF
--- a/examples/player/simid_player.js
+++ b/examples/player/simid_player.js
@@ -580,7 +580,8 @@ class SimidPlayer {
    */
   trackEventsOnAdVideoElement_() {
     this.adVideoTrackingEvents_.set("durationchange", () => {
-      this.simidProtocol.sendMessage(MediaMessage.DURATION_CHANGED);
+      this.simidProtocol.sendMessage(MediaMessage.DURATION_CHANGE,
+        {'duration': this.adVideoElement_.duration});
     });
     this.adVideoTrackingEvents_.set("ended", this.videoComplete.bind(this));
     this.adVideoTrackingEvents_.set("error", () => {


### PR DESCRIPTION
I think there was a mistake in trackEventsOnAdVideoElement_ function for DURATION_CHANGE events