### PR TITLE
Extender creative fix

### DIFF
--- a/examples/creatives/extender.html
+++ b/examples/creatives/extender.html
@@ -66,6 +66,7 @@
       }
       100% {
         opacity:1;
+      }
     }
     </style>
     <script src="../simid_protocol.js"> </script>

--- a/examples/creatives/extender.js
+++ b/examples/creatives/extender.js
@@ -11,6 +11,7 @@ class Extender extends BaseSimidCreative {
 
   /** @override */
   onStart(eventData) {
+    super.onStart(eventData);
     // Don't fetch the media state right away in case the video is not yet loaded.
     setTimeout(() => {
       this.fetchMediaState();


### PR DESCRIPTION
Added super.onStart call
Also added missing bracket in CSS
According to specs, creative must answer on startCreative message to allow player to display it. https://interactiveadvertisingbureau.github.io/SIMID/#workflow-startCreative